### PR TITLE
feat: adicionar validação de tipo de imagem para jpg, jpeg e png na l…

### DIFF
--- a/backend/challenge-backend/src/main/java/com/example/challenge_backend/controller/ProductController.java
+++ b/backend/challenge-backend/src/main/java/com/example/challenge_backend/controller/ProductController.java
@@ -3,7 +3,6 @@ package com.example.challenge_backend.controller;
 import com.example.challenge_backend.dto.product.ProductDTO;
 import com.example.challenge_backend.dto.response.ResponseProductDTO;
 import com.example.challenge_backend.service.ProductService;
-import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
@@ -47,7 +46,7 @@ public class ProductController {
             @RequestParam("image") MultipartFile image) throws IOException {
 
         ProductDTO productDTO = convertToProductDTO(name, price, description, image);
-        ProductDTO createdProduct = productService.create(productDTO);
+        ProductDTO createdProduct = productService.create(productDTO, image);
         URI location = URI.create("/api/products/" + createdProduct.id());
         return ResponseEntity.created(location).body(createdProduct);
     }
@@ -103,7 +102,7 @@ public class ProductController {
         }
 
         ProductDTO productDTO = new ProductDTO(id, name, price, description, imageBytes);
-        ProductDTO updatedProduct = productService.update(id, productDTO);
+        ProductDTO updatedProduct = productService.update(id, productDTO, image);
         return ResponseEntity.ok(new ResponseProductDTO(updatedProduct, "Produto atualizado com sucesso"));
     }
     /**

--- a/backend/challenge-backend/src/main/java/com/example/challenge_backend/service/ProductService.java
+++ b/backend/challenge-backend/src/main/java/com/example/challenge_backend/service/ProductService.java
@@ -16,6 +16,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
@@ -50,7 +51,11 @@ public class ProductService {
      * @return o produto criado
      */
     @Transactional
-    public ProductDTO create(@Valid ProductDTO productDTO) {
+    public ProductDTO create(@Valid ProductDTO productDTO, MultipartFile image) {
+        if (!isValidImageType(image)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid image type. Only JPG, JPEG, and PNG are allowed.");
+        }
+
         try {
             Product product = new Product();
             product.setName(productDTO.name());
@@ -113,7 +118,10 @@ public class ProductService {
      * @return o produto atualizado
      */
     @Transactional
-    public ProductDTO update(Long id, @Valid ProductDTO productDTO) {
+    public ProductDTO update(Long id, @Valid ProductDTO productDTO, MultipartFile image) {
+        if (!isValidImageType(image)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid image type. Only JPG, JPEG, and PNG are allowed.");
+        }
         try {
             Product product = productRepository.findById(id)
                     .orElseThrow(() -> new ResourceNotFoundException("Product not found for this id: " + id));
@@ -191,5 +199,19 @@ public class ProductService {
                 product.getDescription(),
                 product.getImage()
         );
+    }
+
+    /**
+     * Verifica se a imagem enviada é do tipo JPG, JPEG ou PNG.
+     *
+     * @param image a imagem a ser verificada
+     * @return true se a imagem for do tipo permitido, false caso contrário
+     */
+    private boolean isValidImageType(MultipartFile image) {
+        if (image == null) {
+            return false;
+        }
+        String contentType = image.getContentType();
+        return contentType.equals("image/jpeg") || contentType.equals("image/jpg") || contentType.equals("image/png");
     }
 }

--- a/frontend/challenge-frontend/src/app/components/products/product-form/product-form.component.html
+++ b/frontend/challenge-frontend/src/app/components/products/product-form/product-form.component.html
@@ -20,7 +20,7 @@
       </label>
       @if (productForm.get('image')?.hasError('required')) {
         <mat-error>
-          Imagem é obrigatória
+          Imagem é obrigatória.
         </mat-error>
       }
     </div>

--- a/frontend/challenge-frontend/src/app/components/products/product-form/product-form.component.ts
+++ b/frontend/challenge-frontend/src/app/components/products/product-form/product-form.component.ts
@@ -53,12 +53,14 @@ export class ProductFormComponent implements OnInit {
    * @param {ProductService} productService - Serviço para manipulação de produtos
    * @param {FormBuilder} fb - Serviço de construção de formulários
    * @param {MatDialogRef<ProductFormComponent>} dialogRef - Referência ao diálogo
+   * @param notificationService
    * @param {any} data - Dados passados para o diálogo
    */
   constructor(
     private productService: ProductService,
     private fb: FormBuilder,
     public dialogRef: MatDialogRef<ProductFormComponent>,
+    private notificationService: NotificationService,
     @Inject(MAT_DIALOG_DATA) public data: any) {
   }
 
@@ -101,10 +103,16 @@ export class ProductFormComponent implements OnInit {
   onFileSelected(event: Event): void {
     const input = event.target as HTMLInputElement;
     this.isEditMode = false;
-    if (input.files && input.files.length > 0) {
-      const file = input.files[0];
-      this.handleFileSelection(file);
+    if (!input.files || input.files.length === 0) return;
+
+    const file = input.files[0];
+    const validTypes = ['image/jpeg', 'image/jpg', 'image/png'];
+    if (!validTypes.includes(file.type)) {
+      this.handleInvalidFileType();
+      return;
     }
+
+    this.handleFileSelection(file);
   }
 
   /**
@@ -120,6 +128,18 @@ export class ProductFormComponent implements OnInit {
   }
 
   /**
+   * Lida com tipos de arquivos inválidos
+   * @private
+   */
+  private handleInvalidFileType(): void {
+    this.notificationService.showWarning('Tipo de arquivo inválido. Permitido apenas JPG e PNG.');
+    const fileInput = document.getElementById('fileInput') as HTMLInputElement;
+    if (fileInput) {
+      fileInput.value = '';
+    }
+  }
+
+  /**
    * Lê o arquivo selecionado e define a fonte da imagem
    * @param {File} file - Arquivo selecionado
    * @private
@@ -131,6 +151,7 @@ export class ProductFormComponent implements OnInit {
     };
     reader.readAsDataURL(file);
   }
+
 
   /**
    * Fecha o diálogo


### PR DESCRIPTION
…ógica de serviço

- Implementada validação de tipo de imagem diretamente na lógica da `ProductService`.
- Verificação para garantir que apenas imagens dos tipos jpg, jpeg e png sejam aceitas.
- Adicionada consistência na validação de imagens entre o front-end e o back-end.